### PR TITLE
fix(scan): fail closed when scanner exits or report is unparseable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+tests/helpers/uv

--- a/scripts/scan_and_add_skill.sh
+++ b/scripts/scan_and_add_skill.sh
@@ -99,17 +99,19 @@ SCAN_CODE=$?
 set -e
 
 # Decide install policy:
-# - BLOCK only if High or Critical findings exist (unless --force)
+# - BLOCK if the scanner failed, the severity summary is missing, or
+#   High/Critical findings exist (unless --force)
 # - ALLOW Medium/Low/Info, but warn.
 #
 # Reports are markdown; we scrape the "Findings by Severity" summary.
+# Missing/unparseable counts must NOT default to 0 (that fail-opens).
 get_count() {
   local label="$1"
   # Matches lines like: "- **High:** 3" or "- **Critical:** 0"
   local n
   n=$(grep -E "\*\*${label}:\*\*" "$REPORT" 2>/dev/null | head -n 1 | sed -E 's/.*\*\*[^:]+:\*\* *([0-9]+).*/\1/') || true
   if [[ -z "${n:-}" || ! "$n" =~ ^[0-9]+$ ]]; then
-    echo 0
+    echo ""
   else
     echo "$n"
   fi
@@ -125,6 +127,20 @@ DEST_BASE="$STATE_DIR/skills"
 DEST_DIR="$DEST_BASE/$DEST_NAME"
 
 BLOCKED=0
+PARSE_OK=1
+if [[ -z "$CRITICAL_COUNT" || -z "$HIGH_COUNT" ]]; then
+  PARSE_OK=0
+  BLOCKED=1
+  CRITICAL_COUNT="${CRITICAL_COUNT:-0}"
+  HIGH_COUNT="${HIGH_COUNT:-0}"
+fi
+MEDIUM_COUNT="${MEDIUM_COUNT:-0}"
+LOW_COUNT="${LOW_COUNT:-0}"
+INFO_COUNT="${INFO_COUNT:-0}"
+
+if [[ "$SCAN_CODE" -ne 0 ]]; then
+  BLOCKED=1
+fi
 if [[ "$CRITICAL_COUNT" -gt 0 || "$HIGH_COUNT" -gt 0 ]]; then
   BLOCKED=1
 fi
@@ -151,8 +167,14 @@ if [[ $BLOCKED -eq 0 ]]; then
   exit 0
 fi
 
-# Blocked by policy (High/Critical present)
-echo "Scan result: BLOCKED (High/Critical findings present)" >&2
+# Blocked by policy (scanner failure, unparseable report, or High/Critical)
+if [[ "$SCAN_CODE" -ne 0 ]]; then
+  echo "Scan result: BLOCKED (scanner exited $SCAN_CODE)" >&2
+elif [[ "$PARSE_OK" -eq 0 ]]; then
+  echo "Scan result: BLOCKED (could not parse High/Critical counts from report)" >&2
+else
+  echo "Scan result: BLOCKED (High/Critical findings present)" >&2
+fi
 echo "  Critical: $CRITICAL_COUNT  High: $HIGH_COUNT  Medium: $MEDIUM_COUNT  Low: $LOW_COUNT  Info: $INFO_COUNT" >&2
 echo "Report: $REPORT" >&2
 

--- a/tests/helpers/fake-uv
+++ b/tests/helpers/fake-uv
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Test double for `uv run skill-scanner ...`
+# Controlled by FAKE_SCAN_*:
+#   FAKE_SCAN_EXIT   — process exit code (default 0)
+#   FAKE_SCAN_REPORT — markdown written to --output (default empty)
+set -euo pipefail
+
+out=""
+args=("$@")
+i=0
+while [[ $i -lt ${#args[@]} ]]; do
+  if [[ "${args[$i]}" == "--output" ]]; then
+    out="${args[$((i + 1))]:-}"
+  fi
+  i=$((i + 1))
+done
+
+if [[ -n "$out" ]]; then
+  printf '%s' "${FAKE_SCAN_REPORT-}" >"$out"
+fi
+
+exit "${FAKE_SCAN_EXIT:-0}"

--- a/tests/test_fail_open.sh
+++ b/tests/test_fail_open.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Regression tests for issue #3: fail-open install gate.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCAN="$ROOT/scripts/scan_and_add_skill.sh"
+FAKE_UV="$ROOT/tests/helpers/fake-uv"
+chmod +x "$FAKE_UV" "$SCAN"
+
+PASS=0
+FAIL=0
+fail() { echo "FAIL: $*"; FAIL=$((FAIL + 1)); }
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+
+setup_env() {
+  TEST_HOME="$(mktemp -d)"
+  export OPENCLAW_STATE_DIR="$TEST_HOME/state"
+  export OPENCLAW_WORKSPACE_DIR="$TEST_HOME/workspace"
+  mkdir -p "$OPENCLAW_WORKSPACE_DIR/skill-scanner" "$OPENCLAW_STATE_DIR/skills"
+  : >"$OPENCLAW_WORKSPACE_DIR/skill-scanner/.keep"
+  SRC="$(mktemp -d)"
+  echo "skill" >"$SRC/SKILL.md"
+  ln -sfn "$FAKE_UV" "$(dirname "$FAKE_UV")/uv"
+  PATH="$(dirname "$FAKE_UV"):$PATH"
+  export PATH
+}
+
+teardown() {
+  rm -rf "${TEST_HOME:-}" "${SRC:-}"
+}
+
+setup_env
+export FAKE_SCAN_EXIT=1
+export FAKE_SCAN_REPORT=""
+set +e
+"$SCAN" "$SRC" --name crash-skill >/tmp/scan-crash.out 2>/tmp/scan-crash.err
+code=$?
+set -e
+if [[ $code -ne 0 && ! -e "$OPENCLAW_STATE_DIR/skills/crash-skill" ]]; then
+  pass "scanner non-zero exit blocks install"
+else
+  fail "scanner non-zero exit installed or returned 0 (code=$code)"
+fi
+teardown
+
+setup_env
+export FAKE_SCAN_EXIT=0
+export FAKE_SCAN_REPORT=""
+set +e
+"$SCAN" "$SRC" --name empty-report >/tmp/scan-empty.out 2>/tmp/scan-empty.err
+code=$?
+set -e
+if [[ $code -ne 0 && ! -e "$OPENCLAW_STATE_DIR/skills/empty-report" ]]; then
+  pass "empty/unparseable report blocks install"
+else
+  fail "empty report fail-opened (code=$code)"
+fi
+teardown
+
+setup_env
+export FAKE_SCAN_EXIT=0
+export FAKE_SCAN_REPORT=$'- **Critical:** 2\n- **High:** 0\n- **Medium:** 0\n- **Low:** 0\n- **Info:** 0\n'
+set +e
+"$SCAN" "$SRC" --name crit-skill >/tmp/scan-crit.out 2>/tmp/scan-crit.err
+code=$?
+set -e
+if [[ $code -ne 0 && ! -e "$OPENCLAW_STATE_DIR/skills/crit-skill" ]]; then
+  pass "Critical findings block install"
+else
+  fail "Critical findings did not block (code=$code)"
+fi
+teardown
+
+setup_env
+export FAKE_SCAN_EXIT=0
+export FAKE_SCAN_REPORT=$'- **Critical:** 0\n- **High:** 0\n- **Medium:** 1\n- **Low:** 0\n- **Info:** 0\n'
+set +e
+"$SCAN" "$SRC" --name warn-skill >/tmp/scan-warn.out 2>/tmp/scan-warn.err
+code=$?
+set -e
+if [[ $code -eq 0 && -d "$OPENCLAW_STATE_DIR/skills/warn-skill" ]]; then
+  pass "Medium-only findings still install"
+else
+  fail "Medium-only should install (code=$code)"
+fi
+teardown
+
+echo "passed=$PASS failed=$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Why

The install gate fail-opens. `SCAN_CODE` was stored and never read, and `get_count` treated a missing `**High:**` / `**Critical:**` line as `0`. A crashed scanner or a report-format change therefore copied the skill into `~/.openclaw/skills`.

## What Changed

- Block when the scanner exits non-zero.
- Block when High/Critical counts cannot be parsed (empty string, not `0`).
- Keep Medium/Low/Info as allow-with-warning.
- Add `tests/test_fail_open.sh` with a fake `uv` so this does not need cisco-ai-defense/skill-scanner installed.

Fixes #3
