### PR TITLE
fix(clawhub): stage namespaced slugs without embedding slash in mktemp

### DIFF
--- a/scripts/clawhub_scan_install.sh
+++ b/scripts/clawhub_scan_install.sh
@@ -73,7 +73,9 @@ STATE_DIR="${OPENCLAW_STATE_DIR:-$HOME/.openclaw}"
 WORKSPACE_DIR="${OPENCLAW_WORKSPACE_DIR:-$STATE_DIR/workspace}"
 STAGE_ROOT="$WORKSPACE_DIR/.skill_stage"
 mkdir -p "$STAGE_ROOT"
-STAGE_DIR="$(mktemp -d -p "$STAGE_ROOT" "clawhub-${SLUG}-XXXXXXXX")"
+# Do not embed $SLUG in the template — namespaced slugs contain '/'.
+STAGE_DIR="$(mktemp -d -p "$STAGE_ROOT" "clawhub-XXXXXXXX")"
+DEST_NAME="${SLUG##*/}"
 
 cleanup() {
   # Leave staging dir in place if debugging is needed.
@@ -91,17 +93,23 @@ fi
 # We keep everything inside the staging dir.
 ( cd "$STAGE_DIR" && npx -y clawhub --workdir "$STAGE_DIR" --dir skills "${INSTALL_ARGS[@]}" )
 
-CANDIDATE="$STAGE_DIR/skills/$SLUG"
-if [[ ! -d "$CANDIDATE" ]]; then
-  echo "ERROR: clawhub install did not produce expected folder: $CANDIDATE" >&2
+CANDIDATE=""
+for cand in "$STAGE_DIR/skills/$DEST_NAME" "$STAGE_DIR/skills/$SLUG"; do
+  if [[ -d "$cand" ]]; then
+    CANDIDATE="$cand"
+    break
+  fi
+done
+if [[ -z "$CANDIDATE" ]]; then
+  echo "ERROR: clawhub install did not produce expected folder under $STAGE_DIR/skills" >&2
   exit 3
 fi
 
 ADD_SCRIPT="$STATE_DIR/skills/skill-scanner-guard/scripts/scan_and_add_skill.sh"
 if [[ $FORCE -eq 1 ]]; then
-  "$ADD_SCRIPT" "$CANDIDATE" --name "$SLUG" --force
+  "$ADD_SCRIPT" "$CANDIDATE" --name "$DEST_NAME" --force
 else
-  "$ADD_SCRIPT" "$CANDIDATE" --name "$SLUG"
+  "$ADD_SCRIPT" "$CANDIDATE" --name "$DEST_NAME"
 fi
 
 # If we got here, the add script already copied into ~/.openclaw/skills.

--- a/tests/test_namespaced_slug.sh
+++ b/tests/test_namespaced_slug.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Regression tests for issue #4: namespaced ClawHub slugs.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLAW="$ROOT/scripts/clawhub_scan_install.sh"
+
+PASS=0
+FAIL=0
+fail() { echo "FAIL: $*"; FAIL=$((FAIL + 1)); }
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+
+STAGE_ROOT="$(mktemp -d)"
+set +e
+STAGE_DIR=$(mktemp -d -p "$STAGE_ROOT" "clawhub-XXXXXXXX" 2>/tmp/mktemp-ok.err)
+ok_ec=$?
+set -e
+if [[ $ok_ec -eq 0 && -d "${STAGE_DIR:-}" ]]; then
+  pass "mktemp without slug slash works"
+else
+  fail "safe mktemp template failed"
+fi
+rm -rf "$STAGE_ROOT"
+
+if grep -q 'clawhub-${SLUG}-XXXXXXXX' "$CLAW"; then
+  fail "clawhub_scan_install.sh still embeds \$SLUG in mktemp template"
+else
+  pass "clawhub_scan_install.sh mktemp template has no \$SLUG slash"
+fi
+
+if grep -q -- '--name "$SLUG"' "$CLAW"; then
+  fail "clawhub_scan_install.sh still passes full slug as --name"
+else
+  pass "clawhub_scan_install.sh does not pass full slug as --name"
+fi
+
+if grep -q 'DEST_NAME=' "$CLAW" && grep -F 'SLUG##*/' "$CLAW" >/dev/null; then
+  pass "dest name is last path segment"
+else
+  fail "missing DEST_NAME last-segment assignment"
+fi
+
+echo "passed=$PASS failed=$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Why

The advertised ClawHub path cannot install namespaced slugs such as `jason-allen-oneal/skill-scanner-guard`. `mktemp` treated `/` as a directory separator, then `--name "$SLUG"` rejected the slash.

## What Changed

- Stage as `clawhub-XXXXXXXX` (no slug in the template).
- Dest name is `${SLUG##*/}`.
- Accept either `skills/<last-segment>` or `skills/<full-slug>` from clawhub.

Fixes #4
