### PR TITLE
fix(scan): sanitize default dest name so basename .. cannot escape

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+tests/helpers/uv

--- a/scripts/scan_and_add_skill.sh
+++ b/scripts/scan_and_add_skill.sh
@@ -50,11 +50,6 @@ while [[ $# -gt 0 ]]; do
         echo "ERROR: --name requires a value" >&2
         exit 2
       fi
-      # Sanitize DEST_NAME: alphanumeric, hyphen, underscore
-      if [[ ! "$DEST_NAME" =~ ^[a-zA-Z0-9_-]+$ ]]; then
-        echo "ERROR: Invalid name characters (alphanumeric, hyphen, underscore only)" >&2
-        exit 2
-      fi
       shift 2
       ;;
     *)
@@ -64,6 +59,13 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+# Sanitize dest name for both --name and the basename default.
+# Reject ".", "..", slashes, and anything outside [A-Za-z0-9_-].
+if [[ ! "$DEST_NAME" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+  echo "ERROR: Invalid destination name '$DEST_NAME' (alphanumeric, hyphen, underscore only)" >&2
+  exit 2
+fi
 
 STATE_DIR="${OPENCLAW_STATE_DIR:-$HOME/.openclaw}"
 WORKSPACE_DIR="${OPENCLAW_WORKSPACE_DIR:-$STATE_DIR/workspace}"

--- a/tests/helpers/fake-uv
+++ b/tests/helpers/fake-uv
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Test double for `uv run skill-scanner ...`
+# Controlled by FAKE_SCAN_*:
+#   FAKE_SCAN_EXIT   — process exit code (default 0)
+#   FAKE_SCAN_REPORT — markdown written to --output (default empty)
+set -euo pipefail
+
+out=""
+args=("$@")
+i=0
+while [[ $i -lt ${#args[@]} ]]; do
+  if [[ "${args[$i]}" == "--output" ]]; then
+    out="${args[$((i + 1))]:-}"
+  fi
+  i=$((i + 1))
+done
+
+if [[ -n "$out" ]]; then
+  printf '%s' "${FAKE_SCAN_REPORT-}" >"$out"
+fi
+
+exit "${FAKE_SCAN_EXIT:-0}"

--- a/tests/test_dest_name.sh
+++ b/tests/test_dest_name.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Regression tests for issue #5: unsanitized default dest name.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCAN="$ROOT/scripts/scan_and_add_skill.sh"
+FAKE_UV="$ROOT/tests/helpers/fake-uv"
+chmod +x "$FAKE_UV" "$SCAN"
+
+PASS=0
+FAIL=0
+fail() { echo "FAIL: $*"; FAIL=$((FAIL + 1)); }
+pass() { echo "PASS: $*"; PASS=$((PASS + 1)); }
+
+setup_env() {
+  TEST_HOME="$(mktemp -d)"
+  export OPENCLAW_STATE_DIR="$TEST_HOME/state"
+  export OPENCLAW_WORKSPACE_DIR="$TEST_HOME/workspace"
+  mkdir -p "$OPENCLAW_WORKSPACE_DIR/skill-scanner" "$OPENCLAW_STATE_DIR/skills"
+  : >"$OPENCLAW_WORKSPACE_DIR/skill-scanner/.keep"
+  SRC="$(mktemp -d)"
+  echo "skill" >"$SRC/SKILL.md"
+  ln -sfn "$FAKE_UV" "$(dirname "$FAKE_UV")/uv"
+  PATH="$(dirname "$FAKE_UV"):$PATH"
+  export PATH
+}
+
+teardown() {
+  rm -rf "${TEST_HOME:-}" "${SRC:-}"
+}
+
+setup_env
+export FAKE_SCAN_EXIT=0
+export FAKE_SCAN_REPORT=$'- **Critical:** 0\n- **High:** 0\n- **Medium:** 0\n- **Low:** 0\n- **Info:** 0\n'
+DOTDOT="$TEST_HOME/dotdot/.."
+mkdir -p "$TEST_HOME/dotdot"
+set +e
+"$SCAN" "$DOTDOT" >/tmp/scan-dotdot.out 2>/tmp/scan-dotdot.err
+code=$?
+set -e
+if [[ $code -eq 2 ]] && ! grep -q "Installed skill" /tmp/scan-dotdot.out /tmp/scan-dotdot.err 2>/dev/null; then
+  pass "default dest name rejects .."
+else
+  fail "basename .. was accepted (code=$code)"
+fi
+teardown
+
+setup_env
+export FAKE_SCAN_EXIT=0
+export FAKE_SCAN_REPORT=$'- **Critical:** 0\n- **High:** 0\n- **Medium:** 0\n- **Low:** 0\n- **Info:** 0\n'
+set +e
+"$SCAN" "$SRC" --name "skill-scanner-guard" >/tmp/scan-last.out 2>/tmp/scan-last.err
+last_code=$?
+set -e
+if [[ $last_code -eq 0 && -d "$OPENCLAW_STATE_DIR/skills/skill-scanner-guard" ]]; then
+  pass "valid dest name still installs"
+else
+  fail "valid dest name failed (code=$last_code)"
+fi
+teardown
+
+echo "passed=$PASS failed=$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Why

`--name` was sanitized, but the default dest name was raw `basename "$SRC_DIR"`. A source path ending in `..` resolved to `~/.openclaw/skills/..` (the parent of the skills dir).

## What Changed

Apply the same `[A-Za-z0-9_-]` check after argument parsing, covering both `--name` and the default.

Fixes #5
